### PR TITLE
Start of an RnaSeq workflow: Alignment

### DIFF
--- a/rnaseq/align.cwl
+++ b/rnaseq/align.cwl
@@ -1,0 +1,32 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "alignment"
+requirements:
+    - class: SubworkflowFeatureRequirement
+inputs:
+    reference_index:
+        type: File
+        secondaryFiles: [".1.ht2", ".2.ht2", ".3.ht2", ".4.ht2", ".5.ht2", ".6.ht2", ".7.ht2", ".8.ht2"]
+    instrument_data_bam:
+        type: File
+outputs:
+    aligned_bam:
+        type: File
+        outputSource: hisat2_align/aligned_bam
+steps:
+    bam_to_fastq:
+        run: bam_to_fastq.cwl
+        in:
+            bam: instrument_data_bam
+        out:
+            [fastq1, fastq2]
+    hisat2_align:
+        run: hisat2_align.cwl
+        in:
+            reference_index: reference_index
+            fastq1: bam_to_fastq/fastq1
+            fastq2: bam_to_fastq/fastq2
+        out:
+            [aligned_bam]

--- a/rnaseq/bam_to_fastq.cwl
+++ b/rnaseq/bam_to_fastq.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Picard: BAM to FASTQ"
+baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/picard/picard.jar", "SamToFastq"]
+arguments: [ {valueFrom: "F=$(runtime.outdir)/read1.fastq"},
+             {valueFrom: "F2=$(runtime.outdir)/read2.fastq"} ]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 6000
+      tmpdirMin: 25000
+inputs:
+    bam:
+        type: File
+        inputBinding:
+            prefix: "I="
+            separate: false
+            position: 1
+outputs:
+    fastq1:
+        type: File
+        outputBinding:
+            glob: "read1.fastq"
+    fastq2:
+        type: File
+        outputBinding:
+            glob: "read2.fastq"

--- a/rnaseq/hisat2_align.cwl
+++ b/rnaseq/hisat2_align.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "HISAT2: align"
+baseCommand: ["/usr/bin/hisat2", "align"]
+requirements:
+    - class: ShellCommandRequirement
+    - class: ResourceRequirement
+      ramMin: 16000
+      coresMin: 16
+arguments: [
+    "-p", $(runtime.cores),
+    "--dta",
+    "--rna-strandness", "RF",
+    { shellQuote: false, valueFrom: "|" },
+    "/usr/bin/sambamba", "view", "-S", "-f", "bam", "-l", "0", "/dev/stdin",
+    { shellQuote: false, valueFrom: "|" },
+    "/usr/bin/sambamba", "sort", "-t", $(runtime.cores), "-m", "8G", "-o", "$(runtime.outdir)/aligned.bam", "/dev/stdin"
+]
+inputs:
+    reference_index:
+        type: File
+        secondaryFiles: [".1.ht2", ".2.ht2", ".3.ht2", ".4.ht2", ".5.ht2", ".6.ht2", ".7.ht2", ".8.ht2"]
+        inputBinding:
+            prefix: "-x"
+            position: -3
+    fastq1:
+        type: File
+        inputBinding:
+            prefix: "-1"
+            position: -1
+    fastq2:
+        type: File
+        inputBinding:
+            prefix: "-2"
+            position: -2
+outputs:
+    aligned_bam:
+        type: File
+        outputBinding:
+            glob: "aligned.bam"

--- a/rnaseq/merge.cwl
+++ b/rnaseq/merge.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Sambamba: merge"
+baseCommand: ["/usr/bin/sambamba", "merge"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 8000
+      coresMin: 4
+arguments: [
+    "-t", $(runtime.cores),
+    "$(runtime.outdir)/merged.bam"
+]
+inputs:
+    bams:
+        type: File[]
+        inputBinding:
+            position: 1
+outputs:
+    merged_bam:
+        type: File
+        outputBinding:
+            glob: "merged.bam"

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -1,0 +1,34 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "RnaSeq alignment workflow"
+requirements:
+    - class: MultipleInputFeatureRequirement
+    - class: ScatterFeatureRequirement
+    - class: SubworkflowFeatureRequirement
+inputs:
+    reference_index:
+        type: File #this requires an extra file with the basename
+        secondaryFiles: [".1.ht2", ".2.ht2", ".3.ht2", ".4.ht2", ".5.ht2", ".6.ht2", ".7.ht2", ".8.ht2"]
+    instrument_data_bams:
+        type: File[]
+outputs:
+    aligned_bam:
+        type: File
+        outputSource: merge/merged_bam
+steps:
+    align:
+        run: align.cwl
+        scatter: instrument_data_bam
+        in:
+            instrument_data_bam: instrument_data_bams
+            reference_index: reference_index
+        out:
+            [aligned_bam]
+    merge:
+        run: merge.cwl
+        in:
+            bams: align/aligned_bam
+        out:
+            [merged_bam]


### PR DESCRIPTION
This represents step 1 of #144.

One quirk of this version of the implementation: the `reference_index` parameter should point to a file whose name matches the name of the index files but without the extensions (`.1.bt` - `.8.bt`).  This placeholder file can be empty or have whatever contents, but should be small since it will be copied by `toil` alongside the other index files.

(To run, this currently depends on genome/docker-rnaseq#1 to provide the necessary environment.)