### PR TITLE
Updates to `unaligned_bam_to_bqsr` workflow for toil compatibility.

### DIFF
--- a/unaligned_bam_to_bqsr/align_and_tag.cwl
+++ b/unaligned_bam_to_bqsr/align_and_tag.cwl
@@ -4,17 +4,11 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "align with bwa_mem and tag"
 
-baseCommand: ["/bin/bash", "helper.sh"]
+baseCommand: ["/bin/bash", "/usr/bin/alignment_helper.sh"]
 requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/tagged-alignment:2"
     - class: ResourceRequirement
       coresMin: 8
-    - class: InitialWorkDirRequirement
-      listing:
-          - entryname: 'helper.sh'
-            entry: |
-                /usr/local/bin/bwa mem -K 100000000 -t $5 -Y -R "$1" $2 $3 $4 | /usr/local/bin/samblaster -a --addMateTags | /usr/local/bin/samtools view -b -S /dev/stdin
+      ramMin: 16000
 stdout: "refAlign.bam"
 arguments:
     - position: 5

--- a/unaligned_bam_to_bqsr/apply_bqsr.cwl
+++ b/unaligned_bam_to_bqsr/apply_bqsr.cwl
@@ -13,8 +13,6 @@ arguments:
     "-nct", "8",
     "--disable_indel_quals"]
 requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/gatk-3.6:1"
     - class: ResourceRequirement
       ramMin: 16000
 inputs:

--- a/unaligned_bam_to_bqsr/bam_to_cram.cwl
+++ b/unaligned_bam_to_bqsr/bam_to_cram.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: 'BAM to CRAM conversion'
+baseCommand: ["/opt/samtools/bin/samtools", "view", "-C"]
+stdout: "final.cram"
+inputs:
+    reference:
+        type: File
+        inputBinding:
+            prefix: "-T"
+            position: 1
+    bam:
+        type: File
+        inputBinding:
+            position: 2
+outputs:
+    cram:
+        type: stdout

--- a/unaligned_bam_to_bqsr/bqsr.cwl
+++ b/unaligned_bam_to_bqsr/bqsr.cwl
@@ -34,8 +34,6 @@ arguments:
     "-L", "chr22",
     "-nct", "4"]
 requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/gatk-3.6:1"
     - class: ResourceRequirement
       ramMin: 16000
 inputs:

--- a/unaligned_bam_to_bqsr/mark_duplicates_and_sort.cwl
+++ b/unaligned_bam_to_bqsr/mark_duplicates_and_sort.cwl
@@ -4,18 +4,11 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "mark duplicates and sort"
 
-baseCommand: ["/bin/bash", "helper.sh"]
+baseCommand: ["/bin/bash", "/usr/bin/markduplicates_helper.sh"]
 requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/sort-mark-duplicates:2"
     - class: ResourceRequirement
       coresMin: 8
       ramMin: 18000
-    - class: InitialWorkDirRequirement
-      listing:
-          - entryname: 'helper.sh'
-            entry: |
-                /usr/bin/java -Xmx16g -jar /usr/picard/picard.jar MarkDuplicates I=$1 O=/dev/stdout ASSUME_SORT_ORDER=queryname METRICS_FILE=mark_dups_metrics.txt QUIET=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=LENIENT | /usr/local/bin/sambamba sort -t $2 -m 18G -o $3 /dev/stdin
 arguments:
     - position: 2
       valueFrom: $(runtime.cores)

--- a/unaligned_bam_to_bqsr/merge.cwl
+++ b/unaligned_bam_to_bqsr/merge.cwl
@@ -3,11 +3,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'merge BAMs'
-baseCommand: ["/usr/local/bin/samtools", "merge"]
+baseCommand: ["/opt/samtools/bin/samtools", "merge"]
 arguments: ["AlignedMerged.bam"]
-requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/samtools-1.3.1-2:2"
 inputs:
     bams:
         type: File[]

--- a/unaligned_bam_to_bqsr/name_sort.cwl
+++ b/unaligned_bam_to_bqsr/name_sort.cwl
@@ -3,17 +3,16 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'sort BAM by name'
-baseCommand: ["/usr/local/bin/sambamba", "sort"]
+baseCommand: ["/usr/bin/sambamba", "sort"]
 arguments: 
-    ["-t", "8",
+    ["-t", { valueFrom: $(runtime.cores) },
     "-m", "12G",
     "-n",
     "-o", { valueFrom: $(runtime.outdir)/NameSorted.bam }]
 requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/sambamba-0.6.4:1"
     - class: ResourceRequirement
       ramMin: 12000
+      coresMin: 8
 inputs:
     bam:
         type: File

--- a/unaligned_bam_to_bqsr/revert_to_fastq.cwl
+++ b/unaligned_bam_to_bqsr/revert_to_fastq.cwl
@@ -3,15 +3,14 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'revert to fastq'
-baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "SamToFastq"]
+baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/opt/picard/picard.jar", "SamToFastq"]
 arguments:
     ["FASTQ=", { valueFrom: $(runtime.outdir)/revert_to_fastq.rFastq1 },
     "SECOND_END_FASTQ=", { valueFrom: $(runtime.outdir)/revert_to_fastq.rFastq2 }]
 requirements:
-    - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/genome/picard-2.4.1-r:2"
     - class: ResourceRequirement
       ramMin: 16000
+      tmpdirMin: 25000
 inputs:
     bam:
         type: File

--- a/unaligned_bam_to_bqsr/workflow.cwl
+++ b/unaligned_bam_to_bqsr/workflow.cwl
@@ -26,10 +26,9 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
 outputs:
-    final_bam:
+    final_cram:
         type: File
-        outputSource: apply_bqsr/bqsr_bam
-        secondaryFiles: [^.bai]
+        outputSource: bam_to_cram/cram
 steps:
     align:
         scatter: [bam, readgroup]
@@ -75,3 +74,10 @@ steps:
             bqsr_table: bqsr/bqsr_table
         out:
             [bqsr_bam]
+    bam_to_cram:
+        run: bam_to_cram.cwl
+        in:
+            reference: reference
+            bam: apply_bqsr/bqsr_bam
+        out:
+            [cram]

--- a/unaligned_bam_to_bqsr/workflow.cwl
+++ b/unaligned_bam_to_bqsr/workflow.cwl
@@ -44,7 +44,7 @@ steps:
     merge:
         run: merge.cwl
         in:
-            bams: [align/tagged_bam]
+            bams: align/tagged_bam
         out:
             [merged_bam]
     name_sort:


### PR DESCRIPTION
These changes are based on the Dockerfile introduced in genome/docker-unaligned-to-bqsr#1.

Closes #156.