### PR TITLE
Add read-group tag support to the HISAT2 CWL.

### DIFF
--- a/rnaseq/align.cwl
+++ b/rnaseq/align.cwl
@@ -11,6 +11,10 @@ inputs:
         secondaryFiles: [".1.ht2", ".2.ht2", ".3.ht2", ".4.ht2", ".5.ht2", ".6.ht2", ".7.ht2", ".8.ht2"]
     instrument_data_bam:
         type: File
+    read_group_id:
+        type: string
+    read_group_fields:
+        type: string[]
 outputs:
     aligned_bam:
         type: File
@@ -28,5 +32,7 @@ steps:
             reference_index: reference_index
             fastq1: bam_to_fastq/fastq1
             fastq2: bam_to_fastq/fastq2
+            read_group_id: read_group_id
+            read_group_fields: read_group_fields
         out:
             [aligned_bam]

--- a/rnaseq/hisat2_align.cwl
+++ b/rnaseq/hisat2_align.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "HISAT2: align"
-baseCommand: ["/usr/bin/hisat2", "align"]
+baseCommand: ["/usr/bin/hisat2"]
 requirements:
     - class: ShellCommandRequirement
     - class: ResourceRequirement
@@ -29,12 +29,25 @@ inputs:
         type: File
         inputBinding:
             prefix: "-1"
-            position: -1
+            position: -2
     fastq2:
         type: File
         inputBinding:
             prefix: "-2"
-            position: -2
+            position: -1
+    read_group_id:
+        type: string
+        inputBinding:
+            prefix: "--rg-id"
+            position: -5
+    read_group_fields:
+        type:
+            type: array
+            items: string
+            inputBinding:
+                prefix: "--rg"
+        inputBinding:
+            position: -4
 outputs:
     aligned_bam:
         type: File

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -13,6 +13,14 @@ inputs:
         secondaryFiles: [".1.ht2", ".2.ht2", ".3.ht2", ".4.ht2", ".5.ht2", ".6.ht2", ".7.ht2", ".8.ht2"]
     instrument_data_bams:
         type: File[]
+    read_group_id:
+        type: string[]
+    read_group_fields:
+        type:
+            type: array
+            items:
+                type: array
+                items: string
 outputs:
     aligned_bam:
         type: File
@@ -20,10 +28,13 @@ outputs:
 steps:
     align:
         run: align.cwl
-        scatter: instrument_data_bam
+        scatter: [instrument_data_bam, read_group_id, read_group_fields]
+        scatterMethod: dotproduct
         in:
             instrument_data_bam: instrument_data_bams
             reference_index: reference_index
+            read_group_id: read_group_id
+            read_group_fields: read_group_fields
         out:
             [aligned_bam]
     merge:


### PR DESCRIPTION
This uses `scatterMethod: dotproduct`, so each `instrument_data_bam` parameter must have a corresponding `read_group_id` and array of `read_group_fields` listed in the same order.

Closes #159.