### PR TITLE
Set mark duplicates memory request to 40 GB.

### DIFF
--- a/unaligned_bam_to_bqsr/mark_duplicates_and_sort.cwl
+++ b/unaligned_bam_to_bqsr/mark_duplicates_and_sort.cwl
@@ -8,7 +8,7 @@ baseCommand: ["/bin/bash", "/usr/bin/markduplicates_helper.sh"]
 requirements:
     - class: ResourceRequirement
       coresMin: 8
-      ramMin: 18000
+      ramMin: 40000
 arguments:
     - position: 2
       valueFrom: $(runtime.cores)


### PR DESCRIPTION
This step tells Java to use 16GB heap and sambamba to use 18GB, so make sure there's enough to handle both of those plus overhead.