### PR TITLE
Add a read trimming step to RnaSeq alignment.

### DIFF
--- a/rnaseq/align.cwl
+++ b/rnaseq/align.cwl
@@ -15,6 +15,16 @@ inputs:
         type: string
     read_group_fields:
         type: string[]
+    trimming_adapters:
+        type: File
+    trimming_adapter_trim_end:
+        type: string
+    trimming_adapter_min_overlap:
+        type: int
+    trimming_max_uncalled:
+        type: int
+    trimming_min_readlength:
+        type: int
 outputs:
     aligned_bam:
         type: File
@@ -26,12 +36,24 @@ steps:
             bam: instrument_data_bam
         out:
             [fastq1, fastq2]
+    trim_fastq:
+        run: trim_fastq.cwl
+        in:
+            reads1: bam_to_fastq/fastq1
+            reads2: bam_to_fastq/fastq2
+            adapters: trimming_adapters
+            adapter_trim_end: trimming_adapter_trim_end
+            adapter_min_overlap: trimming_adapter_min_overlap
+            max_uncalled: trimming_max_uncalled
+            min_readlength: trimming_min_readlength
+        out:
+            [trimmed_fastq1, trimmed_fastq2]
     hisat2_align:
         run: hisat2_align.cwl
         in:
             reference_index: reference_index
-            fastq1: bam_to_fastq/fastq1
-            fastq2: bam_to_fastq/fastq2
+            fastq1: trim_fastq/trimmed_fastq1
+            fastq2: trim_fastq/trimmed_fastq2
             read_group_id: read_group_id
             read_group_fields: read_group_fields
         out:

--- a/rnaseq/trim_fastq.cwl
+++ b/rnaseq/trim_fastq.cwl
@@ -1,0 +1,61 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Trim FASTQ (flexbar)"
+baseCommand: ['/opt/flexbar/flexbar']
+arguments: [
+    "--target", {valueFrom: "$(runtime.outdir)/trimmed_read"},
+    "--threads", {valueFrom: "$(runtime.cores)"}
+]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 16000
+      tmpdirMin: 25000
+      coresMin: 4
+inputs:
+    adapters:
+        type: File
+        inputBinding:
+            prefix: "--adapters"
+            position: 1
+    adapter_trim_end:
+        type: string
+        inputBinding:
+            prefix: "--adapter-trim-end"
+            position: 2
+    adapter_min_overlap:
+        type: int
+        inputBinding:
+            prefix: "--adapter-min-overlap"
+            position: 3
+    max_uncalled:
+        type: int
+        inputBinding:
+            prefix: "--max-uncalled"
+            position: 5
+    min_readlength:
+        type: int
+        inputBinding:
+            prefix: "--min-read-length"
+            position: 6
+    reads1:
+        type: File
+        inputBinding:
+            prefix: "--reads"
+            position: 7
+    reads2:
+        type: File
+        inputBinding:
+            prefix: "--reads2"
+            position: 8
+outputs:
+    trimmed_fastq1:
+        type: File
+        outputBinding:
+            glob: "trimmed_read_1.fastq"
+    trimmed_fastq2:
+        type: File
+        outputBinding:
+            glob: "trimmed_read_2.fastq"
+

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -25,6 +25,16 @@ inputs:
                 items: string
     sample_name:
         type: string
+    trimming_adapters:
+        type: File
+    trimming_adapter_trim_end:
+        type: string
+    trimming_adapter_min_overlap:
+        type: int
+    trimming_max_uncalled:
+        type: int
+    trimming_min_readlength:
+        type: int
 outputs:
     aligned_bam:
         type: File
@@ -42,6 +52,11 @@ steps:
             reference_index: reference_index
             read_group_id: read_group_id
             read_group_fields: read_group_fields
+            trimming_adapters: trimming_adapters
+            trimming_adapter_trim_end: trimming_adapter_trim_end
+            trimming_adapter_min_overlap: trimming_adapter_min_overlap
+            trimming_max_uncalled: trimming_max_uncalled
+            trimming_min_readlength: trimming_min_readlength
         out:
             [aligned_bam]
     merge:


### PR DESCRIPTION
This uses genome/docker-rnaseq#2 to add read-trimming to the workflow.