### PR TITLE
DNA Alignment: Pipe Interleaved FASTQ

### DIFF
--- a/unaligned_bam_to_bqsr/align.cwl
+++ b/unaligned_bam_to_bqsr/align.cwl
@@ -19,19 +19,11 @@ outputs:
         type: File
         outputSource: align_and_tag/aligned_bam
 steps:
-    revert_to_fastq:
-        run: revert_to_fastq.cwl
-        in:
-            bam: bam
-        out:
-            [fastq, second_end_fastq]
     align_and_tag:
         run: align_and_tag.cwl
         in:
-        in:
+            bam: bam
             readgroup: readgroup
             reference: reference
-            fastq: revert_to_fastq/fastq
-            fastq2: revert_to_fastq/second_end_fastq
         out:
             [aligned_bam]

--- a/unaligned_bam_to_bqsr/align_and_tag.cwl
+++ b/unaligned_bam_to_bqsr/align_and_tag.cwl
@@ -11,25 +11,21 @@ requirements:
       ramMin: 16000
 stdout: "refAlign.bam"
 arguments:
-    - position: 5
+    - position: 4
       valueFrom: $(runtime.cores)
 inputs:
+    bam:
+        type: File
+        inputBinding:
+            position: 1
     readgroup:
         type: string
         inputBinding:
-            position: 1
+            position: 2
     reference:
         type: string
         inputBinding:
-            position: 2
-    fastq:
-        type: File
-        inputBinding:
             position: 3
-    fastq2:
-        type: File
-        inputBinding:
-            position: 4
 outputs:
     aligned_bam:
             type: stdout


### PR DESCRIPTION
CWL changes to support piping of Picard SamToFastq into BWA-MEM as interleaved FASTQ.

Requires https://github.com/genome/docker-dna-alignment/pull/3