### PR TITLE
Update paths to example data files

### DIFF
--- a/example_data/unaligned_bam_to_bqsr/workflow_no_dup_marking.yml
+++ b/example_data/unaligned_bam_to_bqsr/workflow_no_dup_marking.yml
@@ -1,4 +1,4 @@
-reference: /gscmnt/gc2764/cad/HCC1395/toil/refseq/GRCh38DH/GRCh38_full_analysis_set_plus_decoy_hla.fa
+reference: /gscmnt/gc2560/core/model_data/2887491634/build50f99e75d14340ffb5b7d21b03887637/all_sequences.fa
 bams:
     - {class: File, path: /gscmnt/gc2764/cad/instrument_data/imported/62b8ffa0d8544d48b34bb009f6f43ec7/all_sequences.bam}
 readgroups: ['@RG\tID:62b8ffa0d8544d48b34bb009f6f43ec7\tPL:ILLUMINA\tPU:HHV33BBXX-TCCGGAGA.1\tLB:H_IJ-NA12878-NA12878_K10PCRgf-lib1\tSM:H_IJ-NA12878-NA12878_K10']

--- a/example_data/unaligned_bam_to_bqsr/workflow_no_dup_marking.yml
+++ b/example_data/unaligned_bam_to_bqsr/workflow_no_dup_marking.yml
@@ -4,10 +4,10 @@ bams:
 readgroups: ['@RG\tID:62b8ffa0d8544d48b34bb009f6f43ec7\tPL:ILLUMINA\tPU:HHV33BBXX-TCCGGAGA.1\tLB:H_IJ-NA12878-NA12878_K10PCRgf-lib1\tSM:H_IJ-NA12878-NA12878_K10']
 dbsnp:
     class: File
-    path: /gscmnt/gc2764/cad/HCC1395/toil/refseq/GRCh38DH/Homo_sapiens_assembly38.dbsnp138.vcf.gz
+    path: /gscmnt/gc2764/cad/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-19443-e48c595a620a432c93e8dd29e4af64f2/snvs.hq.vcf.gz
 known_indels:
     class: File
-    path: /gscmnt/gc2764/cad/HCC1395/toil/refseq/GRCh38DH/Homo_sapiens_assembly38.known_indels.vcf.gz
+    path: /gscmnt/gc2764/cad/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20267-00cb8ff552914c17ad66d86031e10d30/indels.hq.vcf.gz
 mills:
     class: File
-    path: /gscmnt/gc2764/cad/HCC1395/toil/refseq/GRCh38DH/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
+    path: /gscmnt/gc2764/cad/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20211-26b393cc7ab04120ac68cc2cbd4a15df/indels.hq.vcf.gz


### PR DESCRIPTION
The dbsnp, known indels and milles/1kg indel paths have been updated to the new location in the GMS. Merging to toil_compatibility.
