### PR TITLE
Provide reference to Picard CollectInsertSizeMetrics

### DIFF
--- a/qc/collect_insert_size_metrics.cwl
+++ b/qc/collect_insert_size_metrics.cwl
@@ -16,6 +16,10 @@ inputs:
         inputBinding:
             prefix: "I="
         secondaryFiles: [^.crai]
+    reference:
+        type: string
+        inputBinding:
+            prefix: "REFERENCE_SEQUENCE="
 outputs:
     insert_size_metrics:
         type: File

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -47,6 +47,7 @@ steps:
         run: collect_insert_size_metrics.cwl
         in:
             cram: cram
+            reference: reference
         out:
             [insert_size_metrics]
     collect_alignment_summary_metrics:

--- a/qc/workflow_wgs.cwl
+++ b/qc/workflow_wgs.cwl
@@ -49,6 +49,7 @@ steps:
         run: collect_insert_size_metrics.cwl
         in:
             cram: cram
+            reference: reference
         out:
             [insert_size_metrics]
     collect_alignment_summary_metrics:


### PR DESCRIPTION
Picard was failing with an error about not being able to find `chr1` even though it's in the reference.  Some advice on the GATK forum was to explicitly pass the reference file when using CRAM, so this implements that suggestion.