### PR TITLE
Add step to run add_bam_readcount_to_vcf_helper.py

### DIFF
--- a/detect_variants/add_bam_readcount_to_vcf.cwl
+++ b/detect_variants/add_bam_readcount_to_vcf.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "add bam_readcount info to vcf"
+
+baseCommand: ["/usr/bin/python3", "/usr/bin/add_bam_readcount_to_vcf_helper.py"]
+arguments: 
+    ["TUMOR,NORMAL", $(runtime.outdir)]
+inputs:
+    vcf:
+        type: File
+        inputBinding:
+            position: -2
+    bam_readcount_tsvs:
+        type: 
+            type: array
+            items: File
+        inputBinding:
+            prefix: ""
+            itemSeparator: ","
+            separate: false
+            position: -1
+outputs:
+    annotated_bam_readcount_vcf:
+        type: File
+        outputBinding:
+            glob: "annotated.bam_readcount.vcf.gz"
+

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -62,12 +62,9 @@ outputs:
     vep_summary:
         type: File
         outputSource: annotate_variants/vep_summary
-    snv_bam_readcount:
+    tumor_bam_readcount_tsv:
         type: File
-        outputSource: bam_readcount/snv_bam_readcount
-    indel_bam_readcount:
-        type: File
-        outputSource: bam_readcount/indel_bam_readcount
+        outputSource: bam_readcount/bam_readcount_tsv
 steps:
     varscan:
         run: ../varscan/germline_workflow.cwl
@@ -109,7 +106,7 @@ steps:
             reference_fasta: reference
             bam: cram_to_bam/bam
         out:
-            [snv_bam_readcount, indel_bam_readcount]
+            [bam_readcount_tsv]
     bgzip:
         run: bgzip.cwl
         in:

--- a/example_data/cle_IDT_exome_template.yml
+++ b/example_data/cle_IDT_exome_template.yml
@@ -38,5 +38,5 @@ coding_only: false
 hgvs_annotation: true
 cle_vcf_filter: true
 variants_to_table_fields: [CHROM,POS,ID,REF,ALT,set]
-variants_to_table_genotype_fields: [GT,AD]
+variants_to_table_genotype_fields: [GT,AD,DP,AF]
 vep_to_table_fields: [Consequence,SYMBOL,Feature,HGVSc,HGVSp]

--- a/pvacseq/bam_readcount.cwl
+++ b/pvacseq/bam_readcount.cwl
@@ -5,33 +5,32 @@ class: CommandLineTool
 label: "run bam-readcount"
 
 baseCommand: ["/usr/bin/python", "/usr/bin/bam_readcount_helper.py"]
-arguments:
-    - position: 5
-      valueFrom: $(runtime.outdir)
+requirements:
+    - class: ShellCommandRequirement
+arguments: [
+    $(runtime.outdir),
+    { valueFrom: " && ", shellQuote: false },
+    "/bin/cat", "$(runtime.outdir)/$(inputs.sample)_bam_readcount_snv.tsv", "$(runtime.outdir)/$(inputs.sample)_bam_readcount_indel.tsv"
+]
+stdout: $(inputs.sample)_bam_readcount.tsv
 inputs:
     vcf:
         type: File
         inputBinding:
-            position: 1
+            position: -4
     sample:
         type: string
         inputBinding:
-            position: 2
+            position: -3
     reference_fasta:
         type: string
         inputBinding:
-            position: 3
+            position: -2
     bam:
         type: File
         inputBinding:
-            position: 4
+            position: -1
         secondaryFiles: [.bai]
 outputs:
-    snv_bam_readcount:
-        type: File?
-        outputBinding:
-            glob: $(inputs.sample)_bam_readcount_snv.tsv
-    indel_bam_readcount:
-        type: File?
-        outputBinding:
-            glob: $(inputs.sample)_bam_readcount_indel.tsv
+    bam_readcount_tsv:
+        type: stdout


### PR DESCRIPTION
Add a step to run add_bam_readcount_to_vcf_helper.py so AD, AF, DP info from bam_readcount can be added to vcf format fields. A real toil test is running now.