### PR TITLE
Add add_bam_readcount_to_vcf to tumor_only workflow

### DIFF
--- a/detect_variants/add_bam_readcount_to_vcf.cwl
+++ b/detect_variants/add_bam_readcount_to_vcf.cwl
@@ -5,17 +5,26 @@ class: CommandLineTool
 label: "add bam_readcount info to vcf"
 
 baseCommand: ["/usr/bin/python3", "/usr/bin/add_bam_readcount_to_vcf_helper.py"]
-arguments: 
-    ["TUMOR,NORMAL", $(runtime.outdir)]
+arguments:
+    [$(runtime.outdir)]
 inputs:
     vcf:
         type: File
         inputBinding:
-            position: -2
+            position: -3
     bam_readcount_tsvs:
-        type: 
+        type:
             type: array
             items: File
+        inputBinding:
+            prefix: ""
+            itemSeparator: ","
+            separate: false
+            position: -2
+    sample_names:
+        type:
+            type: array
+            items: string
         inputBinding:
             prefix: ""
             itemSeparator: ","

--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -261,6 +261,8 @@ steps:
         in:
             vcf: annotate_variants/annotated_vcf
             bam_readcount_tsvs: [tumor_bam_readcount/bam_readcount_tsv, normal_bam_readcount/bam_readcount_tsv]
+            sample_names:
+                default: ['TUMOR', 'NORMAL']
         out:
             [annotated_bam_readcount_vcf]
     index:

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -5,6 +5,8 @@ class: Workflow
 label: "Tumor-Only Detect Variants workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type: string
@@ -107,10 +109,23 @@ steps:
             bam: cram_to_bam/bam
         out:
             [bam_readcount_tsv]
+    add_bam_readcount_to_vcf:
+        run: add_bam_readcount_to_vcf.cwl
+        in:
+            - id: vcf
+              source: annotate_variants/annotated_vcf
+            - id: bam_readcount_tsvs
+              source: bam_readcount/bam_readcount_tsv
+              valueFrom: ${ return [ self ]; }
+            - id: sample_names
+              source: sample_name
+              valueFrom: ${ return [ self ]; }
+        out:
+            [annotated_bam_readcount_vcf]
     bgzip:
         run: bgzip.cwl
         in:
-            file: annotate_variants/annotated_vcf
+            file: add_bam_readcount_to_vcf/annotated_bam_readcount_vcf
         out:
             [bgzipped_file]
     index:

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -40,10 +40,10 @@ inputs:
         type: boolean?
     variants_to_table_fields:
         type: string[]?
-        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+        default: [CHROM,POS,ID,REF,ALT]
     variants_to_table_genotype_fields:
         type: string[]?
-        default: [GT,AD]
+        default: [GT,AD,AF,DP]
     vep_to_table_fields:
         type: string[]?
         default: [HGVSc,HGVSp]

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -40,7 +40,7 @@ inputs:
         type: boolean?
     variants_to_table_fields:
         type: string[]?
-        default: [CHROM,POS,ID,REF,ALT]
+        default: [CHROM,POS,ID,REF,ALT, set]
     variants_to_table_genotype_fields:
         type: string[]?
         default: [GT,AD,AF,DP]

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -46,7 +46,7 @@ inputs:
         default: [GT,AD,AF,DP]
     vep_to_table_fields:
         type: string[]?
-        default: [HGVSc,HGVSp]
+        default: [HGVSc,HGVSp,ExAC_NFE_AF,ExAC_AMR_AF,ExAC_SAS_AF,ExAC_Adj_AF,ExAC_AFR_AF,ExAC_OTH_AF,ExAC_FIN_AF,ExAC_AF,ExAC_EAS_AF]
     sample_name:
         type: string
     docm_vcf:

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -122,16 +122,10 @@ steps:
               valueFrom: ${ return [ self ]; }
         out:
             [annotated_bam_readcount_vcf]
-    bgzip:
-        run: bgzip.cwl
-        in:
-            file: add_bam_readcount_to_vcf/annotated_bam_readcount_vcf
-        out:
-            [bgzipped_file]
     index:
         run: index.cwl
         in:
-            vcf: bgzip/bgzipped_file
+            vcf: add_bam_readcount_to_vcf/annotated_bam_readcount_vcf
         out:
             [indexed_vcf]
     variants_to_table:

--- a/docm/germline_workflow.cwl
+++ b/docm/germline_workflow.cwl
@@ -35,7 +35,7 @@ steps:
         out:
             [docm_out]
     docm_filter:
-        run: docm_filter.cwl
+        run: single_sample_docm_filter.cwl
         in:
             docm_out: gatk_haplotypecaller/docm_out
         out:

--- a/docm/single_sample_docm_filter.cwl
+++ b/docm/single_sample_docm_filter.cwl
@@ -1,0 +1,17 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "docm filter"
+arguments: [
+    "/usr/bin/perl", "/usr/bin/single_sample_docm_filter.pl",
+    $(inputs.docm_out.path), $(runtime.outdir)
+]
+inputs:
+    docm_out:
+        type: File
+outputs:
+    docm_filter_out:
+        type: File
+        outputBinding:
+            glob: "docm_filter_out.vcf"

--- a/example_data/detect_variants/add_bam_readcount_to_vcf.yaml
+++ b/example_data/detect_variants/add_bam_readcount_to_vcf.yaml
@@ -1,0 +1,9 @@
+vcf:
+    class: File
+    path: /gscmnt/gc2764/cad/ssiebert/bam_readcount_test/annotated.vcf.gz
+bam_readcount_tsvs:
+    - {class: File, path: /gscmnt/gc2764/cad/ssiebert/bam_readcount_test/TUMOR_bam_readcount.tsv}
+    - {class: File, path: /gscmnt/gc2764/cad/ssiebert/bam_readcount_test/NORMAL_bam_readcount.tsv}
+sample_names:
+    - 'TUMOR'
+    - 'NORMAL'


### PR DESCRIPTION
I ran a test for the add_bam_readcount_to_vcf.cwl with the included add_bam_readcount_to_vcf.yaml. I can move the test data files to the example_data directory, if desired. I haven't tested the changes to the tumor only workflow.