### PR TITLE
Update exome_alignment.cwl with a few new features from the underlying workflows

### DIFF
--- a/exome_alignment.cwl
+++ b/exome_alignment.cwl
@@ -31,6 +31,9 @@ outputs:
     cram:
         type: File
         outputSource: alignment/final_cram
+    mark_duplicates_metrics:
+        type: File
+        outputSource: alignment/mark_duplicates_metrics_file
     insert_size_metrics:
         type: File
         outputSource: qc/insert_size_metrics
@@ -62,7 +65,7 @@ steps:
             mills: mills
             known_indels: known_indels
             dbsnp: dbsnp
-        out: [final_cram]
+        out: [final_cram,mark_duplicates_metrics_file]
     qc:
         run: qc/workflow_exome.cwl
         in:

--- a/exome_alignment.cwl
+++ b/exome_alignment.cwl
@@ -27,6 +27,8 @@ inputs:
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]
+    picard_metric_accumulation_level:
+        type: string
 outputs:
     cram:
         type: File
@@ -74,4 +76,5 @@ steps:
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level
         out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]


### PR DESCRIPTION
* Save the metrics from MarkDuplicates.
* Allow specifying the metric accumulation level for Picard for QC.