### PR TITLE
Point to specific versioned GATK JAR for HaplotypeCaller.

### DIFF
--- a/detect_variants/gatk_haplotypecaller.cwl
+++ b/detect_variants/gatk_haplotypecaller.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "GATK HaplotypeCaller"
-baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "HaplotypeCaller"]
+baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK-3.5.jar", "-T", "HaplotypeCaller"]
 requirements:
     - class: ResourceRequirement
       ramMin: 8000


### PR DESCRIPTION
This is to get around a bug in 3.6.  See also genome/docker-cle#64.