### PR TITLE
Keep the tabix index for the gVCF in the GATK HC output.

### DIFF
--- a/detect_variants/gatk_haplotypecaller.cwl
+++ b/detect_variants/gatk_haplotypecaller.cwl
@@ -61,3 +61,4 @@ outputs:
         type: File
         outputBinding:
             glob: "*.g.vcf.gz"
+        secondaryFiles: [.tbi]

--- a/detect_variants/gatk_haplotypecaller_iterator.cwl
+++ b/detect_variants/gatk_haplotypecaller_iterator.cwl
@@ -29,6 +29,7 @@ outputs:
     gvcf:
         type: File[]
         outputSource: haplotype_caller/gvcf
+        secondaryFiles: [.tbi]
 steps:
     haplotype_caller:
         scatter: [intervals]


### PR DESCRIPTION
GATK makes these index files automatically, so might as well retain them.