### PR TITLE
Add optional parameter for base metric output in CollectHsMetrics.

### DIFF
--- a/exome_alignment.cwl
+++ b/exome_alignment.cwl
@@ -46,8 +46,11 @@ outputs:
         type: File
         outputSource: qc/hs_metrics
     per_target_coverage_metrics:
-        type: File
+        type: File?
         outputSource: qc/per_target_coverage_metrics
+    per_base_coverage_metrics:
+        type: File?
+        outputSource: qc/per_base_coverage_metrics
     flagstats:
         type: File
         outputSource: qc/flagstats
@@ -77,4 +80,4 @@ steps:
             target_intervals: target_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
-        out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+        out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]

--- a/qc/collect_hs_metrics.cwl
+++ b/qc/collect_hs_metrics.cwl
@@ -35,6 +35,10 @@ inputs:
         type: boolean?
         inputBinding:
             prefix: "PER_TARGET_COVERAGE=PerTargetCoverage.txt"
+    per_base_coverage:
+        type: boolean?
+        inputBinding:
+            prefix: "PER_BASE_COVERAGE=PerBaseCoverage.txt"
 outputs:
     hs_metrics:
         type: File
@@ -44,3 +48,7 @@ outputs:
         type: File?
         outputBinding:
             glob: "PerTargetCoverage.txt"
+    per_base_coverage_metrics:
+        type: File?
+        outputBinding:
+            glob: "PerBaseCoverage.txt"

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -20,6 +20,8 @@ inputs:
         secondaryFiles: [.tbi]
     collect_hs_metrics_per_target_coverage:
         type: boolean?
+    collect_hs_metrics_per_base_coverage:
+        type: boolean?
     picard_metric_accumulation_level:
         type: string?
         default: ALL_READS
@@ -36,6 +38,9 @@ outputs:
     per_target_coverage_metrics:
         type: File?
         outputSource: collect_hs_metrics/per_target_coverage_metrics
+    per_base_coverage_metrics:
+        type: File?
+        outputSource: collect_hs_metrics/per_base_coverage_metrics
     flagstats:
         type: File
         outputSource: samtools_flagstat/flagstats
@@ -71,8 +76,9 @@ steps:
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_target_coverage: collect_hs_metrics_per_target_coverage
+            per_base_coverage: collect_hs_metrics_per_base_coverage
         out:
-            [hs_metrics, per_target_coverage_metrics]
+            [hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics]
     samtools_flagstat:
         run: samtools_flagstat.cwl
         in:


### PR DESCRIPTION
There is no boolean flag at the top level alignment workflow, but we can
hardcode a true value in any processing-profiles that need it.  (The `CwlPipeline` wrapper in genome still doesn't easily support boolean flags as inputs, so we'd probably hardcode the value, anyway.)

This addresses #247.