### PR TITLE
Skip running VEP filters on empty VCF files.

### DIFF
--- a/detect_variants/coding_variant_filter.cwl
+++ b/detect_variants/coding_variant_filter.cwl
@@ -3,9 +3,12 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "Coding Variant filter"
-baseCommand: ["/usr/bin/perl", "/opt/vep/ensembl-vep/filter_vep"]
+baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
 arguments:
-    ["--format", "vcf",
+    [{ valueFrom: $(inputs.vcf.path) },
+    { valueFrom: $(runtime.outdir)/annotated.coding_variant_filtered.vcf },
+    "/usr/bin/perl", "/opt/vep/ensembl-vep/filter_vep",
+    "--format", "vcf",
     "-o", { valueFrom: $(runtime.outdir)/annotated.coding_variant_filtered.vcf },
     "--ontology",
     "--filter", "Consequence is coding_sequence_variant"]

--- a/detect_variants/exac_filter.cwl
+++ b/detect_variants/exac_filter.cwl
@@ -3,11 +3,14 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "ExAC filter"
-baseCommand: ["/usr/bin/perl", "/opt/vep/ensembl-vep/filter_vep"]
+baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
 requirements:
     - class: InlineJavascriptRequirement
 arguments:
-    ["--format", "vcf",
+    [{ valueFrom: $(inputs.vcf.path) },
+    { valueFrom: $(runtime.outdir)/annotated.exac_filtered.vcf },
+    "/usr/bin/perl", "/opt/vep/ensembl-vep/filter_vep",
+    "--format", "vcf",
     "-o", { valueFrom: $(runtime.outdir)/annotated.exac_filtered.vcf }]
 inputs:
     vcf:

--- a/detect_variants/max_af_filter.cwl
+++ b/detect_variants/max_af_filter.cwl
@@ -3,11 +3,14 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "MAX_AF filter"
-baseCommand: ["/usr/bin/perl", "/opt/vep/ensembl-vep/filter_vep"]
+baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
 requirements:
     - class: InlineJavascriptRequirement
 arguments:
-    ["--format", "vcf",
+    [{ valueFrom: $(inputs.vcf.path) },
+    { valueFrom: $(runtime.outdir)/annotated.max_af_filtered.vcf },
+    "/usr/bin/perl", "/opt/vep/ensembl-vep/filter_vep",
+    "--format", "vcf",
     "-o", { valueFrom: $(runtime.outdir)/annotated.max_af_filtered.vcf }]
 inputs:
     vcf:


### PR DESCRIPTION
VEP fails to output anything in this case, which breaks downstream steps.  This uses genome/docker-cle#66 to skip running and copy the input file to the output.