### PR TITLE
Add .tbi as secondaryFile for the DoCM VCF in tumor-only Detect Variants

### DIFF
--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -56,8 +56,8 @@ inputs:
         type: int
         default: 400
     docm_vcf:
-         type: File
-         secondaryFiles: [.tbi]
+        type: File
+        secondaryFiles: [.tbi]
     vep_cache_dir:
         type: string?
     synonyms_file:

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -56,6 +56,7 @@ inputs:
         type: string
     docm_vcf:
         type: File
+        secondaryFiles: [.tbi]
 outputs:
     varscan_vcf:
         type: File


### PR DESCRIPTION
This brings it in line with the somatic workflow and satisfies the needs of the HaplotypeCaller.