### PR TITLE
Expect known_sites files to be tabix indexed.

### DIFF
--- a/unaligned_bam_to_bqsr/bqsr.cwl
+++ b/unaligned_bam_to_bqsr/bqsr.cwl
@@ -55,6 +55,7 @@ inputs:
             inputBinding:
                 prefix: "-knownSites"
                 position: 3
+        secondaryFiles: [.tbi]
 outputs:
     bqsr_table:
         type: File


### PR DESCRIPTION
The `.tbi` indexes are already required for the inputs to the workflow.cwl in this directory, so let's pass them along!

Closes #259.