### PR TITLE
Second attempt: Fix gnomADe test vcf

### DIFF
--- a/example_data/exome_workflow.tgz.md5
+++ b/example_data/exome_workflow.tgz.md5
@@ -1,0 +1,1 @@
+858e4f6d7cde9a80da9cba734bd4adc5  exome_workflow.tgz


### PR DESCRIPTION
The tar archive was truncated and added an md5.