### PR TITLE
CRAM and QC for molecular UMI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ At this time, the toil_compatibility branch relies on large, a/k/a fat, Docker i
 | detect_variants | mgibio/cle | detect_variants/detect_variants.cwl |
 | rnaseq | mgibio/rnaseq | rnaseq/workflow.cwl |
 | tumor_only_exome | mgibio/cle | exome_workflow.cwl |
+| umi_alignment | mgibio/dna-alignment | umi_alignment/duplex_workflow.cwl |
 
 If a tool or workflow is a subworkflow of a larger workflow, then the same Docker image is required.
 

--- a/umi_alignment/alignment_workflow.cwl
+++ b/umi_alignment/alignment_workflow.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "umi per-lane alignment subworkflow"
+requirements:
+    - class: SubworkflowFeatureRequirement
+inputs:
+    bam:
+        type: File
+    read_structure:
+        type: string[]
+    reference: string
+outputs:
+    aligned_bam:
+        type: File
+        secondaryFiles: [^.bai]
+        outputSource: align/aligned_bam
+    adapter_metrics:
+        type: File
+        outputSource: mark_illumina_adapters/metrics
+steps:
+    extract_umis:
+        run: extract_umis.cwl
+        in:
+            bam: bam
+            read_structure: read_structure
+        out:
+            [umi_extracted_bam]
+    mark_illumina_adapters:
+        run: mark_illumina_adapters.cwl
+        in:
+            bam: extract_umis/umi_extracted_bam
+        out:
+            [marked_bam, metrics]
+    align:
+        run: align.cwl
+        in:
+            bam: mark_illumina_adapters/marked_bam
+            reference: reference
+        out:
+            [aligned_bam]

--- a/umi_alignment/duplex_alignment_workflow.cwl
+++ b/umi_alignment/duplex_alignment_workflow.cwl
@@ -2,12 +2,13 @@
 
 cwlVersion: v1.0
 class: Workflow
-label: "umi alignment workflow"
+label: "umi duplex alignment workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: ScatterFeatureRequirement
 inputs:
     bam:
-        type: File
+        type: File[]
     sample_name:
         type: string
     read_structure:
@@ -22,36 +23,31 @@ outputs:
         secondaryFiles: [^.bai]
         outputSource: clip_overlap/clipped_bam
     adapter_histogram:
-        type: File
-        outputSource: mark_illumina_adapters/metrics
+        type: File[]
+        outputSource: align/adapter_metrics
     duplex_seq_metrics:
         type: File[]
         outputSource: collect_duplex_seq_metrics/duplex_seq_metrics
 steps:
-    extract_umis:
-        run: extract_umis.cwl
+    align:
+        scatter: bam
+        run: alignment_workflow.cwl
         in:
             bam: bam
             read_structure: read_structure
-        out:
-            [umi_extracted_bam]
-    mark_illumina_adapters:
-        run: mark_illumina_adapters.cwl
-        in:
-            bam: extract_umis/umi_extracted_bam
-        out:
-            [marked_bam, metrics]
-    align:
-        run: align.cwl
-        in:
-            bam: mark_illumina_adapters/marked_bam
             reference: reference
         out:
-            [aligned_bam]
+            [aligned_bam, adapter_metrics]
+    merge:
+        run: merge.cwl
+        in:
+            bams: align/aligned_bam
+        out:
+            [merged_bam]
     group_reads_by_umi:
         run: group_reads.cwl
         in:
-            bam: align/aligned_bam
+            bam: merge/merged_bam
         out:
             [grouped_bam]
     call_duplex_consensus:

--- a/umi_alignment/duplex_workflow.cwl
+++ b/umi_alignment/duplex_workflow.cwl
@@ -2,22 +2,23 @@
 
 cwlVersion: v1.0
 class: Workflow
-label: "umi alignment workflow"
+label: "umi duplex alignment fastq workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: ScatterFeatureRequirement
 inputs:
     read1_fastq:
-        type: File
+        type: File[]
     read2_fastq:
-        type: File
+        type: File[]
     sample_name:
         type: string
     library_name:
-        type: string
+        type: string[]
     platform_unit:
-        type: string
+        type: string[]
     platform:
-        type: string
+        type: string[]
     read_structure:
         type: string[]
     reference:
@@ -30,13 +31,15 @@ outputs:
         secondaryFiles: [^.bai]
         outputSource: alignment_workflow/aligned_bam
     adapter_histogram:
-        type: File
+        type: File[]
         outputSource: alignment_workflow/adapter_histogram
     duplex_seq_metrics:
         type: File[]
         outputSource: alignment_workflow/duplex_seq_metrics
 steps:
     fastq_to_bam:
+        scatter: [read1_fastq, read2_fastq, library_name, platform_unit, platform]
+        scatterMethod: dotproduct
         run: fastq_to_bam.cwl
         in:
             read1_fastq: read1_fastq

--- a/umi_alignment/merge.cwl
+++ b/umi_alignment/merge.cwl
@@ -1,0 +1,17 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: 'merge BAMs'
+baseCommand: ["/opt/samtools/bin/samtools", "merge"]
+arguments: ["AlignedMerged.bam"]
+inputs:
+    bams:
+        type: File[]
+        inputBinding:
+            position: 1
+outputs:
+    merged_bam:
+        type: File
+        outputBinding:
+            glob: "AlignedMerged.bam"

--- a/umi_alignment/molecular_alignment_workflow.cwl
+++ b/umi_alignment/molecular_alignment_workflow.cwl
@@ -18,10 +18,10 @@ inputs:
     target_intervals:
        type: File?
 outputs:
-    aligned_bam:
+    aligned_cram:
         type: File
-        secondaryFiles: [^.bai]
-        outputSource: clip_overlap/clipped_bam
+        secondaryFiles: [.crai, ^.crai]
+        outputSource: index_cram/indexed_cram
     adapter_histogram:
         type: File[]
         outputSource: align/adapter_metrics
@@ -85,3 +85,16 @@ steps:
             description: sample_name
        out:
             [duplex_seq_metrics]
+    bam_to_cram:
+        run: ../unaligned_bam_to_bqsr/bam_to_cram.cwl
+        in:
+            bam: clip_overlap/clipped_bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+        run: ../unaligned_bam_to_bqsr/index_cram.cwl
+        in:
+            cram: bam_to_cram/cram
+        out:
+            [indexed_cram]

--- a/umi_alignment/molecular_workflow.cwl
+++ b/umi_alignment/molecular_workflow.cwl
@@ -26,10 +26,10 @@ inputs:
     target_intervals:
        type: File?
 outputs:
-    aligned_bam:
+    aligned_cram:
         type: File
-        secondaryFiles: [^.bai]
-        outputSource: alignment_workflow/aligned_bam
+        secondaryFiles: [.crai, ^.crai]
+        outputSource: alignment_workflow/aligned_cram
     adapter_histogram:
         type: File[]
         outputSource: alignment_workflow/adapter_histogram
@@ -59,4 +59,4 @@ steps:
             reference: reference
             target_intervals: target_intervals
         out:
-            [aligned_bam, adapter_histogram, duplex_seq_metrics]
+            [aligned_cram, adapter_histogram, duplex_seq_metrics]

--- a/umi_alignment/molecular_workflow.cwl
+++ b/umi_alignment/molecular_workflow.cwl
@@ -2,22 +2,23 @@
 
 cwlVersion: v1.0
 class: Workflow
-label: "umi alignment workflow"
+label: "umi molecular alignment fastq workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: ScatterFeatureRequirement
 inputs:
     read1_fastq:
-        type: File
+        type: File[]
     read2_fastq:
-        type: File
+        type: File[]
     sample_name:
         type: string
     library_name:
-        type: string
+        type: string[]
     platform_unit:
-        type: string
+        type: string[]
     platform:
-        type: string
+        type: string[]
     read_structure:
         type: string[]
     reference:
@@ -30,13 +31,15 @@ outputs:
         secondaryFiles: [^.bai]
         outputSource: alignment_workflow/aligned_bam
     adapter_histogram:
-        type: File
+        type: File[]
         outputSource: alignment_workflow/adapter_histogram
     duplex_seq_metrics:
         type: File[]
         outputSource: alignment_workflow/duplex_seq_metrics
 steps:
     fastq_to_bam:
+        scatter: [read1_fastq, read2_fastq, library_name, platform_unit, platform]
+        scatterMethod: dotproduct
         run: fastq_to_bam.cwl
         in:
             read1_fastq: read1_fastq


### PR DESCRIPTION
This PR includes the entirety of #281.  Beyond that, it adds CRAM conversion and introduces a new workflow to run the exome QC after the alignment process has completed.