### PR TITLE
Run CollectHsMetrics with additional coverage targets.

### DIFF
--- a/exome_alignment.cwl
+++ b/exome_alignment.cwl
@@ -26,6 +26,10 @@ inputs:
         type: File
     target_intervals:
         type: File
+    per_target_intervals:
+        type: File
+    per_base_intervals:
+        type: File
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -81,6 +85,8 @@ steps:
             reference: reference
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            per_target_intervals: per_target_intervals
+            per_base_intervals: per_base_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
         out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]

--- a/exome_alignment.cwl
+++ b/exome_alignment.cwl
@@ -58,9 +58,15 @@ outputs:
     per_target_coverage_metrics:
         type: File?
         outputSource: qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File?
+        outputSource: qc/per_target_hs_metrics
     per_base_coverage_metrics:
         type: File?
         outputSource: qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File?
+        outputSource: qc/per_base_hs_metrics
     flagstats:
         type: File
         outputSource: qc/flagstats
@@ -95,4 +101,4 @@ steps:
             per_base_bait_intervals: per_base_bait_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
-        out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+        out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]

--- a/exome_alignment.cwl
+++ b/exome_alignment.cwl
@@ -28,7 +28,11 @@ inputs:
         type: File
     per_target_intervals:
         type: File
+    per_target_bait_intervals:
+        type: File
     per_base_intervals:
+        type: File
+    per_base_bait_intervals:
         type: File
     omni_vcf:
         type: File
@@ -86,7 +90,9 @@ steps:
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_target_intervals: per_target_intervals
+            per_target_bait_intervals: per_target_bait_intervals
             per_base_intervals: per_base_intervals
+            per_base_bait_intervals: per_base_bait_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
         out: [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]

--- a/exome_workflow.cwl
+++ b/exome_workflow.cwl
@@ -103,9 +103,15 @@ outputs:
     per_target_coverage_metrics:
         type: File?
         outputSource: alignment_and_qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File?
+        outputSource: alignment_and_qc/per_target_hs_metrics
     per_base_coverage_metrics:
         type: File?
         outputSource: alignment_and_qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File?
+        outputSource: alignment_and_qc/per_base_hs_metrics
     flagstats:
         type: File
         outputSource: alignment_and_qc/flagstats
@@ -159,7 +165,7 @@ steps:
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [cram, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     detect_variants:
         run: detect_variants/tumor_only_detect_variants.cwl
         in:

--- a/exome_workflow.cwl
+++ b/exome_workflow.cwl
@@ -28,7 +28,11 @@ inputs:
         type: File
     per_target_intervals:
         type: File
+    per_target_bait_intervals:
+        type: File
     per_base_intervals:
+        type: File
+    per_base_bait_intervals:
         type: File
     omni_vcf:
         type: File
@@ -149,7 +153,9 @@ steps:
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_target_intervals: per_target_intervals
+            per_target_bait_intervals: per_target_bait_intervals
             per_base_intervals: per_base_intervals
+            per_base_bait_intervals: per_base_bait_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
         out:

--- a/exome_workflow.cwl
+++ b/exome_workflow.cwl
@@ -26,6 +26,10 @@ inputs:
         type: File
     target_intervals:
         type: File
+    per_target_intervals:
+        type: File
+    per_base_intervals:
+        type: File
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -144,6 +148,8 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            per_target_intervals: per_target_intervals
+            per_base_intervals: per_base_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
         out:

--- a/germline_exome_workflow.cwl
+++ b/germline_exome_workflow.cwl
@@ -28,7 +28,11 @@ inputs:
         type: File
     per_target_intervals:
         type: File
+    per_target_bait_intervals:
+        type: File
     per_base_intervals:
+        type: File
+    per_base_bait_intervals:
         type: File
     omni_vcf:
         type: File
@@ -93,7 +97,9 @@ steps:
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_target_intervals: per_target_intervals
+            per_target_bait_intervals: per_target_bait_intervals
             per_base_intervals: per_base_intervals
+            per_base_bait_intervals: per_base_bait_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
         out:

--- a/germline_exome_workflow.cwl
+++ b/germline_exome_workflow.cwl
@@ -68,9 +68,15 @@ outputs:
     per_target_coverage_metrics:
         type: File?
         outputSource: alignment_and_qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File?
+        outputSource: alignment_and_qc/per_target_hs_metrics
     per_base_coverage_metrics:
         type: File?
         outputSource: alignment_and_qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File?
+        outputSource: alignment_and_qc/per_base_hs_metrics
     flagstats:
         type: File
         outputSource: alignment_and_qc/flagstats
@@ -103,7 +109,7 @@ steps:
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [cram, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     extract_freemix:
         in:
             verify_bam_id_metrics: alignment_and_qc/verify_bam_id_metrics

--- a/germline_exome_workflow.cwl
+++ b/germline_exome_workflow.cwl
@@ -26,6 +26,10 @@ inputs:
         type: File
     target_intervals:
         type: File
+    per_target_intervals:
+        type: File
+    per_base_intervals:
+        type: File
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -88,6 +92,8 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            per_target_intervals: per_target_intervals
+            per_base_intervals: per_base_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
         out:

--- a/qc/collect_hs_metrics.cwl
+++ b/qc/collect_hs_metrics.cwl
@@ -9,6 +9,7 @@ arguments:
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
+    - class: InlineJavascriptRequirement
 inputs:
     cram:
         type: File
@@ -34,11 +35,27 @@ inputs:
     per_target_coverage:
         type: boolean?
         inputBinding:
-            prefix: "PER_TARGET_COVERAGE=$(inputs.output_prefix)-PerTargetCoverage.txt"
+            prefix: "PER_TARGET_COVERAGE="
+            valueFrom: |
+                        ${
+                            if(self) {
+                                return inputs.output_prefix + "-PerTargetCoverage.txt"
+                            } else {
+                                return false;
+                            }
+                        }
     per_base_coverage:
         type: boolean?
         inputBinding:
-            prefix: "PER_BASE_COVERAGE=$(inputs.output_prefix)-PerBaseCoverage.txt"
+            prefix: "PER_BASE_COVERAGE="
+            valueFrom: |
+                        ${
+                            if(self) {
+                                return inputs.output_prefix + "-PerBaseCoverage.txt"
+                            } else {
+                                return false;
+                            }
+                        }
     output_prefix:
         type: string?
         default: "out"

--- a/qc/collect_hs_metrics.cwl
+++ b/qc/collect_hs_metrics.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "collect HS metrics"
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectHsMetrics"]
 arguments:
-    ["O=", { valueFrom: $(runtime.outdir)/HsMetrics.txt }]
+    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.output_prefix)-HsMetrics.txt }]
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
@@ -34,21 +34,24 @@ inputs:
     per_target_coverage:
         type: boolean?
         inputBinding:
-            prefix: "PER_TARGET_COVERAGE=PerTargetCoverage.txt"
+            prefix: "PER_TARGET_COVERAGE=$(inputs.output_prefix)-PerTargetCoverage.txt"
     per_base_coverage:
         type: boolean?
         inputBinding:
-            prefix: "PER_BASE_COVERAGE=PerBaseCoverage.txt"
+            prefix: "PER_BASE_COVERAGE=$(inputs.output_prefix)-PerBaseCoverage.txt"
+    output_prefix:
+        type: string?
+        default: "out"
 outputs:
     hs_metrics:
         type: File
         outputBinding:
-            glob: "HsMetrics.txt"
+            glob: "*HsMetrics.txt"
     per_target_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "PerTargetCoverage.txt"
+            glob: "*PerTargetCoverage.txt"
     per_base_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "PerBaseCoverage.txt"
+            glob: "*PerBaseCoverage.txt"

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -82,7 +82,8 @@ steps:
         in:
             cram: cram
             reference: reference
-            metric_accumulation_level: picard_metric_accumulation_level
+            metric_accumulation_level:
+                valueFrom: "ALL_READS"
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_target_coverage:
@@ -98,7 +99,8 @@ steps:
         in:
             cram: cram
             reference: reference
-            metric_accumulation_level: picard_metric_accumulation_level
+            metric_accumulation_level:
+                valueFrom: "ALL_READS"
             bait_intervals: per_base_bait_intervals
             target_intervals: per_base_intervals
             per_target_coverage:
@@ -114,7 +116,8 @@ steps:
         in:
             cram: cram
             reference: reference
-            metric_accumulation_level: picard_metric_accumulation_level
+            metric_accumulation_level:
+                valueFrom: "ALL_READS"
             bait_intervals: per_target_bait_intervals
             target_intervals: per_target_intervals
             per_target_coverage:

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -38,13 +38,19 @@ outputs:
         outputSource: collect_alignment_summary_metrics/alignment_summary_metrics
     hs_metrics:
         type: File
-        outputSource: collect_hs_metrics/hs_metrics
+        outputSource: collect_roi_hs_metrics/hs_metrics
     per_target_coverage_metrics:
         type: File?
-        outputSource: collect_per_target_metrics/per_target_coverage_metrics
+        outputSource: collect_per_target_hs_metrics/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File?
+        outputSource: collect_per_target_hs_metrics/hs_metrics
     per_base_coverage_metrics:
         type: File?
-        outputSource: collect_per_base_metrics/per_base_coverage_metrics
+        outputSource: collect_per_base_hs_metrics/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File?
+        outputSource: collect_per_base_hs_metrics/hs_metrics
     flagstats:
         type: File
         outputSource: samtools_flagstat/flagstats
@@ -71,7 +77,7 @@ steps:
             metric_accumulation_level: picard_metric_accumulation_level
         out:
             [alignment_summary_metrics]
-    collect_hs_metrics:
+    collect_roi_hs_metrics:
         run: collect_hs_metrics.cwl
         in:
             cram: cram
@@ -83,9 +89,11 @@ steps:
                 default: false
             per_base_coverage:
                 default: false
+            output_prefix:
+                valueFrom: "roi"
         out:
             [hs_metrics]
-    collect_per_base_metrics:
+    collect_per_base_hs_metrics:
         run: collect_hs_metrics.cwl
         in:
             cram: cram
@@ -97,9 +105,11 @@ steps:
                 default: false
             per_base_coverage:
                 default: true
+            output_prefix:
+                valueFrom: "base"
         out:
-            [per_base_coverage_metrics]
-    collect_per_target_metrics:
+            [hs_metrics, per_base_coverage_metrics]
+    collect_per_target_hs_metrics:
         run: collect_hs_metrics.cwl
         in:
             cram: cram
@@ -111,8 +121,10 @@ steps:
                 default: true
             per_base_coverage:
                 default: false
+            output_prefix:
+                valueFrom: "target"
         out:
-            [per_target_coverage_metrics]
+            [hs_metrics, per_target_coverage_metrics]
     samtools_flagstat:
         run: samtools_flagstat.cwl
         in:

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -87,7 +87,7 @@ steps:
             cram: cram
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
-            bait_intervals: bait_intervals
+            bait_intervals: per_base_intervals
             target_intervals: per_base_intervals
             per_target_coverage:
                 default: false
@@ -101,7 +101,7 @@ steps:
             cram: cram
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
-            bait_intervals: bait_intervals
+            bait_intervals: per_target_intervals
             target_intervals: per_target_intervals
             per_target_coverage:
                 default: true

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -20,7 +20,11 @@ inputs:
         secondaryFiles: [.tbi]
     per_target_intervals:
         type: File
+    per_target_bait_intervals:
+        type: File
     per_base_intervals:
+        type: File
+    per_base_bait_intervals:
         type: File
     picard_metric_accumulation_level:
         type: string?
@@ -87,7 +91,7 @@ steps:
             cram: cram
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
-            bait_intervals: per_base_intervals
+            bait_intervals: per_base_bait_intervals
             target_intervals: per_base_intervals
             per_target_coverage:
                 default: false
@@ -101,7 +105,7 @@ steps:
             cram: cram
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
-            bait_intervals: per_target_intervals
+            bait_intervals: per_target_bait_intervals
             target_intervals: per_target_intervals
             per_target_coverage:
                 default: true

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -18,10 +18,10 @@ inputs:
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]
-    collect_hs_metrics_per_target_coverage:
-        type: boolean?
-    collect_hs_metrics_per_base_coverage:
-        type: boolean?
+    per_target_intervals:
+        type: File
+    per_base_intervals:
+        type: File
     picard_metric_accumulation_level:
         type: string?
         default: ALL_READS
@@ -37,10 +37,10 @@ outputs:
         outputSource: collect_hs_metrics/hs_metrics
     per_target_coverage_metrics:
         type: File?
-        outputSource: collect_hs_metrics/per_target_coverage_metrics
+        outputSource: collect_per_target_metrics/per_target_coverage_metrics
     per_base_coverage_metrics:
         type: File?
-        outputSource: collect_hs_metrics/per_base_coverage_metrics
+        outputSource: collect_per_base_metrics/per_base_coverage_metrics
     flagstats:
         type: File
         outputSource: samtools_flagstat/flagstats
@@ -75,10 +75,40 @@ steps:
             metric_accumulation_level: picard_metric_accumulation_level
             bait_intervals: bait_intervals
             target_intervals: target_intervals
-            per_target_coverage: collect_hs_metrics_per_target_coverage
-            per_base_coverage: collect_hs_metrics_per_base_coverage
+            per_target_coverage:
+                default: false
+            per_base_coverage:
+                default: false
         out:
-            [hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics]
+            [hs_metrics]
+    collect_per_base_metrics:
+        run: collect_hs_metrics.cwl
+        in:
+            cram: cram
+            reference: reference
+            metric_accumulation_level: picard_metric_accumulation_level
+            bait_intervals: bait_intervals
+            target_intervals: per_base_intervals
+            per_target_coverage:
+                default: false
+            per_base_coverage:
+                default: true
+        out:
+            [per_base_coverage_metrics]
+    collect_per_target_metrics:
+        run: collect_hs_metrics.cwl
+        in:
+            cram: cram
+            reference: reference
+            metric_accumulation_level: picard_metric_accumulation_level
+            bait_intervals: bait_intervals
+            target_intervals: per_target_intervals
+            per_target_coverage:
+                default: true
+            per_base_coverage:
+                default: false
+        out:
+            [per_target_coverage_metrics]
     samtools_flagstat:
         run: samtools_flagstat.cwl
         in:

--- a/umi_alignment/molecular_qc_workflow.cwl
+++ b/umi_alignment/molecular_qc_workflow.cwl
@@ -55,9 +55,15 @@ outputs:
     per_target_coverage_metrics:
         type: File?
         outputSource: qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File?
+        outputSource: qc/per_target_hs_metrics
     per_base_coverage_metrics:
         type: File?
         outputSource: qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File?
+        outputSource: qc/per_base_hs_metrics
     flagstats:
         type: File
         outputSource: qc/flagstats
@@ -92,4 +98,4 @@ steps:
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
         out:
-            [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_base_coverage_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]

--- a/umi_alignment/molecular_qc_workflow.cwl
+++ b/umi_alignment/molecular_qc_workflow.cwl
@@ -19,6 +19,10 @@ inputs:
         type: File
     bait_intervals:
         type: File
+    per_target_intervals:
+        type: File
+    per_base_intervals:
+        type: File
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -77,6 +81,8 @@ steps:
             reference: reference
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
         out:

--- a/umi_alignment/molecular_qc_workflow.cwl
+++ b/umi_alignment/molecular_qc_workflow.cwl
@@ -21,7 +21,11 @@ inputs:
         type: File
     per_target_intervals:
         type: File
+    per_target_bait_intervals:
+        type: File
     per_base_intervals:
+        type: File
+    per_base_bait_intervals:
         type: File
     omni_vcf:
         type: File
@@ -82,7 +86,9 @@ steps:
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_base_intervals: per_base_intervals
+            per_base_bait_intervals: per_base_bait_intervals
             per_target_intervals: per_target_intervals
+            per_target_bait_intervals: per_target_bait_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level
         out:


### PR DESCRIPTION
This change makes the per-base and per-target coverage required.

This is part of #297.