### PR TITLE
Remove ShellCommandRequirement from vep.cwl

### DIFF
--- a/detect_variants/vep.cwl
+++ b/detect_variants/vep.cwl
@@ -5,7 +5,6 @@ class: CommandLineTool
 label: "Ensembl Variant Effect Predictor"
 baseCommand: ["/usr/bin/perl", "-I", "/opt/lib/perl/VEP/Plugins", "/usr/bin/variant_effect_predictor.pl"]
 requirements:
-    - class: ShellCommandRequirement
     - class: InlineJavascriptRequirement
     - class: ResourceRequirement
       ramMin: 32000


### PR DESCRIPTION
This is a holdover from an earlier version that was `cat`ting files to help build the command-line.