### PR TITLE
Made -q and -b bam_readcount flags user definable

### DIFF
--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -264,8 +264,8 @@ steps:
                 default: 'NORMAL'
             reference_fasta: reference
             bam: normal_cram_to_bam/bam
-            min_base_quality: min_base_quality
-            min_mapping_quality: min_mapping_quality
+            min_base_quality: minimum_base_quality
+            min_mapping_quality: minimum_mapping_quality
         out:
             [bam_readcount_tsv]
     add_tumor_bam_readcount_to_vcf:

--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -30,9 +30,9 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    min_base_quality:
+    minimum_base_quality:
         type: int?
-    min_mapping_quality:
+    minimum_mapping_quality:
         type: int?
     mutect_scatter_count:
         type: int?
@@ -252,8 +252,8 @@ steps:
                 default: 'TUMOR'
             reference_fasta: reference
             bam: tumor_cram_to_bam/bam
-            min_base_quality: min_base_quality
-            min_mapping_quality: min_mapping_quality
+            min_base_quality: minimum_base_quality
+            min_mapping_quality: minimum_mapping_quality
         out:
             [bam_readcount_tsv]
     normal_bam_readcount:

--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -30,6 +30,10 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
+    min_base_quality:
+        type: int?
+    min_mapping_quality:
+        type: int?
     mutect_scatter_count:
         type: int?
     mutect_artifact_detection_mode:
@@ -248,6 +252,8 @@ steps:
                 default: 'TUMOR'
             reference_fasta: reference
             bam: tumor_cram_to_bam/bam
+            min_base_quality: min_base_quality
+            min_mapping_quality: min_mapping_quality
         out:
             [bam_readcount_tsv]
     normal_bam_readcount:
@@ -258,6 +264,8 @@ steps:
                 default: 'NORMAL'
             reference_fasta: reference
             bam: normal_cram_to_bam/bam
+            min_base_quality: min_base_quality
+            min_mapping_quality: min_mapping_quality
         out:
             [bam_readcount_tsv]
     add_tumor_bam_readcount_to_vcf:

--- a/detect_variants/tumor_only_detect_variants.cwl
+++ b/detect_variants/tumor_only_detect_variants.cwl
@@ -60,6 +60,10 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    min_mapping_quality:
+        type: int?
+    min_base_quality:
+        type: int?
 outputs:
     varscan_vcf:
         type: File
@@ -143,6 +147,8 @@ steps:
             sample: sample_name
             reference_fasta: reference
             bam: cram_to_bam/bam
+            min_mapping_quality: min_mapping_quality
+            min_base_quality: min_base_quality
         out:
             [bam_readcount_tsv]
     add_bam_readcount_to_vcf:

--- a/exome_workflow.cwl
+++ b/exome_workflow.cwl
@@ -84,6 +84,10 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    min_mapping_quality:
+        type: int?
+    min_base_quality:
+        type: int?
 outputs:
     cram:
         type: File
@@ -187,5 +191,7 @@ steps:
             docm_vcf: docm_vcf
             hgvs_annotation: hgvs_annotation
             custom_gnomad_vcf: custom_gnomad_vcf
+            min_mapping_quality: min_mapping_quality
+            min_base_quality: min_base_quality
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv]

--- a/exome_workflow.cwl
+++ b/exome_workflow.cwl
@@ -196,7 +196,7 @@ steps:
             docm_vcf: docm_vcf
             hgvs_annotation: hgvs_annotation
             custom_gnomad_vcf: custom_gnomad_vcf
-            min_mapping_quality: min_mapping_quality
-            min_base_quality: min_base_quality
+            min_mapping_quality: minimum_mapping_quality
+            min_base_quality: minimum_base_quality
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv]

--- a/pvacseq/bam_readcount.cwl
+++ b/pvacseq/bam_readcount.cwl
@@ -14,6 +14,16 @@ arguments: [
 ]
 stdout: $(inputs.sample)_bam_readcount.tsv
 inputs:
+    min_mapping_quality:
+        type: int?
+        default: -1
+        inputBinding:
+            position: -6
+    min_base_quality:
+        type: int?
+        default: -1
+        inputBinding:
+            position: -5
     vcf:
         type: File
         inputBinding:

--- a/pvacseq/bam_readcount.cwl
+++ b/pvacseq/bam_readcount.cwl
@@ -14,32 +14,33 @@ arguments: [
 ]
 stdout: $(inputs.sample)_bam_readcount.tsv
 inputs:
-    min_mapping_quality:
-        type: int?
+    vcf:
+        type: File
         inputBinding:
             position: -6
+    sample:
+        type: string
+        inputBinding:
+            position: -5
+    reference_fasta:
+        type: string
+        inputBinding:
+            position: -4
+    bam:
+        type: File
+        inputBinding:
+            position: -3
+        secondaryFiles: [.bai]
+    min_mapping_quality:
+        type: int?
+        default: 0
+        inputBinding:
+            position: -2
     min_base_quality:
         type: int?
         default: 20
         inputBinding:
-            position: -5
-    vcf:
-        type: File
-        inputBinding:
-            position: -4
-    sample:
-        type: string
-        inputBinding:
-            position: -3
-    reference_fasta:
-        type: string
-        inputBinding:
-            position: -2
-    bam:
-        type: File
-        inputBinding:
             position: -1
-        secondaryFiles: [.bai]
 outputs:
     bam_readcount_tsv:
         type: stdout

--- a/pvacseq/bam_readcount.cwl
+++ b/pvacseq/bam_readcount.cwl
@@ -31,14 +31,14 @@ inputs:
         inputBinding:
             position: -3
         secondaryFiles: [.bai]
-    min_mapping_quality:
-        type: int?
-        default: 0
-        inputBinding:
-            position: -2
     min_base_quality:
         type: int?
         default: 20
+        inputBinding:
+            position: -2
+    min_mapping_quality:
+        type: int?
+        default: 0
         inputBinding:
             position: -1
 outputs:

--- a/pvacseq/bam_readcount.cwl
+++ b/pvacseq/bam_readcount.cwl
@@ -16,12 +16,11 @@ stdout: $(inputs.sample)_bam_readcount.tsv
 inputs:
     min_mapping_quality:
         type: int?
-        default: -1
         inputBinding:
             position: -6
     min_base_quality:
         type: int?
-        default: -1
+        default: 20
         inputBinding:
             position: -5
     vcf:

--- a/wgs_workflow.cwl
+++ b/wgs_workflow.cwl
@@ -40,6 +40,10 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    min_mapping_quality:
+        type: int?
+    min_base_quality:
+        type: int?
 outputs:
     cram:
         type: File
@@ -133,5 +137,7 @@ steps:
             sample_name: sample_name
             docm_vcf: docm_vcf
             custom_gnomad_vcf: custom_gnomad_vcf
+            min_mapping_quality: min_mapping_quality
+            min_base_quality: min_base_quality
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv]


### PR DESCRIPTION
Modified ./pvacseq/bam_readcount.cwl and all upstream dependencies to optionally accept -q (minimum mapping quality) and -b (minimum base quality) flags. Should close issue #214 