### PR TITLE
Stringtie now accepts strandedness flag

### DIFF
--- a/rnaseq/stringtie.cwl
+++ b/rnaseq/stringtie.cwl
@@ -14,20 +14,30 @@ arguments: [
     "-n", $(runtime.cores)
 ]
 inputs:
+    firststrand:
+        type: boolean?
+        inputBinding:
+            prefix: "--rf"
+            position: 1
+    secondstrand:
+        type: boolean?
+        inputBinding:
+            prefix: "--fr"
+            position: 1
     reference_annotation:
         type: File
         inputBinding:
             prefix: "-G"
-            position: 1
+            position: 2
     sample_name:
         type: string
         inputBinding:
             prefix: "-l"
-            position: 2
+            position: 3
     bam:
         type: File
         inputBinding:
-            position: 3
+            position: 4
 outputs:
     transcript_gtf:
         type: File

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -123,5 +123,7 @@ steps:
             bam: merge/merged_bam
             reference_annotation: reference_annotation
             sample_name: sample_name
+            firststrand: firststrand
+            secondstrand: secondstrand
         out:
             [transcript_gtf,gene_expression_tsv]

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -2,7 +2,7 @@
 
 cwlVersion: v1.0
 class: Workflow
-label: "RNA-Seq alignment and transcript/gene abundance workflow - first-stranded data"
+label: "RNA-Seq alignment and transcript/gene abundance workflow"
 requirements:
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement


### PR DESCRIPTION
Added in two optional parameters that can add --rf or --fr flags to stringtie; this should resolve issue #202. Possibly builds on https://github.com/genome/cancer-genomics-workflow/commit/3cd5ee0003faacec8a92a4b50faff89a2d8f5ac9