### PR TITLE
added in missing parameters so that the tutorial will work

### DIFF
--- a/example_data/exome_workflow.yaml
+++ b/example_data/exome_workflow.yaml
@@ -25,6 +25,18 @@ mills:
 omni_vcf:
   class: File
   path: exome_workflow/chr17_test_omni.vcf.gz
+per_base_bait_intervals:
+  class: File
+  path: exome_workflow/chr17_test_bait.interval_list
+per_base_intervals:
+  class: File
+  path: exome_workflow/chr17_test_target.interval_list
+per_target_bait_intervals:
+  class: File
+  path: exome_workflow/chr17_test_bait.interval_list
+per_target_intervals:
+  class: File
+  path: exome_workflow/chr17_test_target.interval_list
 picard_metric_accumulation_level: ALL_READS
 readgroups:
 - "@RG\tID:2895499223\tPU:H7HY2CCXX.3.ATCACGGT\tSM:H_NJ-HCC1395-HCC1395\tLB:H_NJ-HCC1395-HCC1395-lg24-lib1\tPL:Illumina\tCN:WUGSC"


### PR DESCRIPTION
Changes in #298 introduced some parameters that were not added into the tutorial YAML file, causing it to immediately error out. Added those parameters, pipeline test in the [tutorial](https://confluence.ris.wustl.edu/display/CI/Toil) now works normally.