### PR TITLE
Removed unused parameter to fix travis validation warning

### DIFF
--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -48,7 +48,7 @@ outputs:
     final_bam:
         type: File
         outputSource: index_bam/indexed_bam
-        secondaryFiles: [.bai, ^.bai]
+        secondaryFiles: [.bai]
     stringtie_transcript_gtf:
         type: File
         outputSource: stringtie/transcript_gtf


### PR DESCRIPTION
Travis CI logs from the cwl validator tool showed 2 secondary outputs expected from a tool run from the rnaseq workflow cwl, but the tool itself only generates one output. Removed the unnecessary expected output from the workflow script.