### PR TITLE
adding kallisto fusion preprocessing step

### DIFF
--- a/rnaseq/kallisto.cwl
+++ b/rnaseq/kallisto.cwl
@@ -12,6 +12,7 @@ arguments: [
     "quant",
     "-t", $(runtime.cores),
     "-b", "100",
+    "--fusion",
     "-o", "kallisto",
 ]
 inputs:
@@ -47,3 +48,7 @@ outputs:
         type: File
         outputBinding:
             glob: "kallisto/abundance.h5"
+    fusion_inputs:
+        type: File
+        outputBinding:
+            glob: "kallisto/fusion.txt"

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -36,7 +36,7 @@ inputs:
         type: int
     trimming_min_readlength:
         type: int
-    kallisto_index: 
+    kallisto_index:
        type: File
     gene_transcript_lookup_table:
        type: File
@@ -92,12 +92,12 @@ steps:
             kallisto_index: kallisto_index
             firststrand: firststrand
             secondstrand: secondstrand
-            fastqs: 
+            fastqs:
                 source: bam_to_trimmed_fastq_and_hisat_alignments/fastqs
                 valueFrom: |
                     ${
                       for(var i=0;i<self.length;i++){self[i] = self[i].reverse()}
-                      return(self)                      
+                      return(self)
                      }
         out:
             [expression_transcript_table,expression_transcript_h5,fusion_inputs]

--- a/rnaseq/workflow.cwl
+++ b/rnaseq/workflow.cwl
@@ -64,6 +64,9 @@ outputs:
     gene_abundance:
         type: File
         outputSource: transcript_to_gene/gene_abundance
+    fusion_inputs:
+        type: File
+        outputSource: kallisto/fusion_inputs
 steps:
     bam_to_trimmed_fastq_and_hisat_alignments:
         run: bam_to_trimmed_fastq_and_hisat_alignments.cwl
@@ -97,7 +100,7 @@ steps:
                       return(self)                      
                      }
         out:
-            [expression_transcript_table,expression_transcript_h5]
+            [expression_transcript_table,expression_transcript_h5,fusion_inputs]
     transcript_to_gene:
         run: transcript_to_gene.cwl
         in:


### PR DESCRIPTION
This step adds very little overhead, and provides the input needed to run pizzly for fusion detection.