### PR TITLE
Use the input prefix to construct expected output names.

### DIFF
--- a/qc/collect_hs_metrics.cwl
+++ b/qc/collect_hs_metrics.cwl
@@ -73,12 +73,12 @@ outputs:
     hs_metrics:
         type: File
         outputBinding:
-            glob: "*HsMetrics.txt"
+            glob: "$(input.output_prefix)-HsMetrics.txt"
     per_target_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "*PerTargetCoverage.txt"
+            glob: "$(input.output_prefix)-PerTargetCoverage.txt"
     per_base_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "*PerBaseCoverage.txt"
+            glob: "$(input.output_prefix)-PerBaseCoverage.txt"


### PR DESCRIPTION
The `*` in the `glob` led to broadinstitute/cromwell#4004 when testing with cromwell. We already know what value to expect, so use it instead!